### PR TITLE
__builtin_avr_delay_cycles(1) replaced by __asm__("nop")

### DIFF
--- a/NHD-2.7-12864WD/NHD-2.7-12864WD.ino
+++ b/NHD-2.7-12864WD/NHD-2.7-12864WD.ino
@@ -88,6 +88,8 @@ unsigned char NHD_Logo[] = {
  *                 Function Commands                  
  *****************************************************/
 
+
+
 // Data Output Serial Interface
 void data(unsigned char d) 
 {
@@ -102,12 +104,12 @@ void data(unsigned char d)
     } else {
       digitalWrite(OLED_MOSI, LOW);
     }
-    __builtin_avr_delay_cycles(1);
+    __asm__("nop");
     d = (d << 1);
     digitalWrite(OLED_CLK, LOW);
-    __builtin_avr_delay_cycles(1);
+    __asm__("nop");
     digitalWrite(OLED_CLK, HIGH);
-    __builtin_avr_delay_cycles(1);
+    __asm__("nop");
     digitalWrite(OLED_CLK, LOW);
   }
   digitalWrite(OLED_CS, HIGH);
@@ -127,12 +129,12 @@ void command(unsigned char d)
     } else {
       digitalWrite(OLED_MOSI, LOW);
     }
-    __builtin_avr_delay_cycles(1);
+    __asm__("nop");
     d = (d << 1);
     digitalWrite(OLED_CLK, LOW);
-    __builtin_avr_delay_cycles(1);
+    __asm__("nop");
     digitalWrite(OLED_CLK, HIGH);
-    __builtin_avr_delay_cycles(1);
+    __asm__("nop");
     digitalWrite(OLED_CLK, LOW);
   }
   digitalWrite(OLED_CS, HIGH);


### PR DESCRIPTION
Replaced __builtin_avr_delay_cycles(1) by __asm__("nop") in order to be compliant with Arduino Zero. Tested ok !